### PR TITLE
Round position in pad()

### DIFF
--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -110,6 +110,16 @@ def test_contain(new_size):
     assert new_im.size == (256, 256)
 
 
+def test_contain_round():
+    im = Image.new("1", (43, 63), 1)
+    new_im = ImageOps.contain(im, (5, 7))
+    assert new_im.width == 5
+
+    im = Image.new("1", (63, 43), 1)
+    new_im = ImageOps.contain(im, (7, 5))
+    assert new_im.height == 5
+
+
 def test_pad():
     # Same ratio
     im = hopper()

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -140,6 +140,15 @@ def test_pad():
             )
 
 
+def test_pad_round():
+    im = Image.new("1", (1, 1), 1)
+    new_im = ImageOps.pad(im, (4, 1))
+    assert new_im.load()[2, 0] == 1
+
+    new_im = ImageOps.pad(im, (1, 4))
+    assert new_im.load()[0, 2] == 1
+
+
 def test_pil163():
     # Division by zero in equalize if < 255 pixels in image (@PIL163)
 

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -292,10 +292,10 @@ def pad(image, size, method=Image.Resampling.BICUBIC, color=None, centering=(0.5
     else:
         out = Image.new(image.mode, size, color)
         if resized.width != size[0]:
-            x = int((size[0] - resized.width) * max(0, min(centering[0], 1)))
+            x = round((size[0] - resized.width) * max(0, min(centering[0], 1)))
             out.paste(resized, (x, 0))
         else:
-            y = int((size[1] - resized.height) * max(0, min(centering[1], 1)))
+            y = round((size[1] - resized.height) * max(0, min(centering[1], 1)))
             out.paste(resized, (0, y))
     return out
 


### PR DESCRIPTION
Two suggestions for https://github.com/python-pillow/Pillow/pull/6522

1. I've added a test for your existing change. Tests are helpful to prevent us accidentally reverting your change in the future.
2. If we're applying rounding in `contain()`, why not in `pad()` as well?